### PR TITLE
Update wice_grid.gemspec

### DIFF
--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.date          = '2018-11-28'
 
-  s.add_dependency 'rails', '~> 5.0', '< 5.3'
+  s.add_dependency 'rails', '>= 5.0'
   s.add_dependency 'kaminari',          ['~> 1.1.0']
   s.add_dependency 'coffee-rails',      ['> 3.2']
 


### PR DESCRIPTION
Adjust dependency for wicegrid to function with rails 6.

With this, we should be able to use Wicegrid functionality fine on rails 6: no changes from rails 5.2 to 6.0 seem to break functionality